### PR TITLE
Fix download link for dgxtop .deb package

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A performance monitoring CLI tool for Ubuntu inspired by asitop for Mac, with ad
 Download the `.deb` package and install:
 
 ```bash
-wget  https://github.com/GigCoder-ai/dgxtop/blob/main/deb_build/dgxtop_1.0.0-1_all.deb
+wget https://github.com/GigCoder-ai/dgxtop/raw/refs/heads/main/deb_build/dgxtop_1.0.0-1_all.deb
 sudo apt install ./dgxtop_1.0.0-1_all.deb
 ```
 


### PR DESCRIPTION
## Description
Fixes the download link for the `.deb` package in `README.md`. The original link pointed to the GitHub file preview page; this change updates it to the raw file URL to ensure the `wget` command correctly downloads the package.

## Related Issue
N/A

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

### Code Quality
- [ ] My code follows the PEP 8 style guidelines
- [x] I have reviewed my own code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings

### Testing
- [ ] I have run the test suite and all tests pass
- [ ] I have added tests that prove my fix/feature works
- [ ] I have tested on Linux with Python 3.8+

### Hardware Testing (for GPU-related changes)
- [ ] I have tested on NVIDIA hardware with nvidia-smi
- [x] N/A - This change does not affect GPU functionality
- [ ] I don't have access to NVIDIA hardware (maintainer will test)

### Documentation
- [x] I have updated the README if needed
- [x] I have updated docstrings for any modified functions

## Screenshots (if applicable)
N/A

## Additional Notes
The link has been updated to: `https://github.com/GigCoder-ai/dgxtop/raw/refs/heads/main/deb_build/dgxtop_1.0.0-1_all.deb`